### PR TITLE
fix type error in set color temperature

### DIFF
--- a/milight_ibox2/milight_ibox2_control.py
+++ b/milight_ibox2/milight_ibox2_control.py
@@ -362,7 +362,7 @@ class MilightIBox:
             print("Send color temperature %dK zone %d..." % (color_temperature, zone))
 
         # Calculate color temperature byte
-        ct = (color_temperature - 2700) / ((6500-2700)/100) & 0xFF
+        ct = int((color_temperature - 2700) / ((6500-2700)/100)) & 0xFF
 
         self.send_command(bytearray([0x31, 0x00, 0x00, lamp_type,
                                      0x05, ct, 0x00, 0x00, 0x00, zone, 0x00]))


### PR DESCRIPTION
Hi,
I just tested your recent changes, and it worked great, thank you! There was only one small bug remaining, which caused a bitwise AND to be performed between a float and an integer, which I fixed here. Thanks again for your effort!
Best regards